### PR TITLE
feat: Add email validation for password input

### DIFF
--- a/src/app/[lang]/register/form.tsx
+++ b/src/app/[lang]/register/form.tsx
@@ -63,10 +63,10 @@ export function Form({ cedula }: Props) {
           level: 'error',
           extra: err.config
             ? {
-              message: err.message,
-              url: err.config.url,
-              method: err.config.method.toUpperCase(),
-            }
+                message: err.message,
+                url: err.config.url,
+                method: err.config.method.toUpperCase(),
+              }
             : undefined,
         });
         AlertWarning(intl.errors.registration.flow);

--- a/src/app/[lang]/register/form.tsx
+++ b/src/app/[lang]/register/form.tsx
@@ -63,10 +63,10 @@ export function Form({ cedula }: Props) {
           level: 'error',
           extra: err.config
             ? {
-                message: err.message,
-                url: err.config.url,
-                method: err.config.method.toUpperCase(),
-              }
+              message: err.message,
+              url: err.config.url,
+              method: err.config.method.toUpperCase(),
+            }
             : undefined,
         });
         AlertWarning(intl.errors.registration.flow);

--- a/src/common/validation-schemas/register.schema.ts
+++ b/src/common/validation-schemas/register.schema.ts
@@ -10,17 +10,22 @@ export const createRegisterSchema = (
     .object({
       email: z.string().email(validations.email.invalid),
       emailConfirm: z.string().email(validations.email.invalid),
-      password: z.string().min(8),
-      passwordConfirm: z.string().min(8),
+      password: z.string().min(10, validations.password.minimum),
+      passwordConfirm: z.string().min(10, validations.password.minimum),
     })
-    .refine(({ password }) => !password.includes(cedula), {
-      message: validations.password.hasID,
-      path: ['password'],
-    })
-    .refine(({ passwordConfirm }) => !passwordConfirm.includes(cedula), {
-      message: validations.password.hasID,
-      path: ['passwordConfirm'],
-    })
+    .refine(
+      (data) => {
+        const [email] = data.email.split('@');
+        return (
+          !data.password.includes(cedula) &&
+          !data.password.toLowerCase().includes(email.toLowerCase())
+        );
+      },
+      {
+        message: validations.password.similarity,
+        path: ['password'],
+      },
+    )
     .refine((data) => data.email === data.emailConfirm, {
       message: validations.email.noMatch,
       path: ['emailConfirm'],

--- a/src/dictionaries/en.json
+++ b/src/dictionaries/en.json
@@ -234,7 +234,8 @@
     "password": {
       "empty": "Password cannot be empty",
       "noMatch": "Passwords do not match",
-      "hasID": "Your password cannot contain your ID number."
+      "minimum": "The Password must contain at least 10 characters.",
+      "similarity": "The Password cannot contain parts of your ID or Email"
     },
     "required": "Required field"
   },

--- a/src/dictionaries/es.json
+++ b/src/dictionaries/es.json
@@ -234,7 +234,8 @@
     "password": {
       "empty": "La Contraseña no puede estar vacía",
       "noMatch": "Las Contraseñas no coinciden",
-      "hasID": "La contraseña no puede contener el número de cédula."
+      "minimum": "La Contraseña debe contener al menos 10 caracteres.",
+      "similarity": "La Contraseña no puede contener partes de su cédula o Correo Electrónico."
     },
     "required": "Campo requerido"
   },


### PR DESCRIPTION
Added validation that the password does not contain parts of the email and removed a validation in passwordConfirm that is already being done in the 'password' path of createRegisterSchema