### PR TITLE
fix: fix object sent to ORY to calculate last names correctly

### DIFF
--- a/src/app/[lang]/register/form.tsx
+++ b/src/app/[lang]/register/form.tsx
@@ -145,7 +145,7 @@ export function Form({ cedula }: Props) {
           username: citizen.id,
           name: {
             first: citizen.names,
-            last: `${citizen.firstSurname} ${citizen.secondSurname}`,
+            last: `${citizen.firstSurname ?? ''} ${citizen.secondSurname ?? ''}`,
           },
           birthdate: citizen.birthDate,
           gender: citizen.gender,


### PR DESCRIPTION
Adjusted the logic for calculating last names when sending the object to ORY. If the second last name is null, it is now ignored when calculating the 'last' property