### PR TITLE
fix (cicd): Adding right permissions to pipelines

### DIFF
--- a/.github/workflows/cd-deploy-to-dev.yml
+++ b/.github/workflows/cd-deploy-to-dev.yml
@@ -1,5 +1,7 @@
 name: Deploy to dev
 
+permissions: read-all
+
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/cd-deploy-to-prod.yml
+++ b/.github/workflows/cd-deploy-to-prod.yml
@@ -1,5 +1,7 @@
 name: Deploy to prod
 
+permissions: read-all
+
 on:
   release:
     types:

--- a/.github/workflows/cd-deploy-to-test.yml
+++ b/.github/workflows/cd-deploy-to-test.yml
@@ -1,5 +1,7 @@
 name: Deploy to test
 
+permissions: read-all
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/ci-check-linters.yml
+++ b/.github/workflows/ci-check-linters.yml
@@ -1,5 +1,7 @@
 name: Lint Code Base
 
+permissions: read-all
+
 on:
   pull_request:
     branches: [master]

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -1,5 +1,7 @@
 name: Unit Tests
 
+permissions: read-all
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -1,5 +1,7 @@
 name: Delete Cloud Run instances on PR closed by merged
 
+permissions: read-all
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/sub-build-push-image.yml
+++ b/.github/workflows/sub-build-push-image.yml
@@ -1,5 +1,7 @@
 name: Build docker image
 
+permissions: read-all
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/sub-cloudrun-deploy.yml
+++ b/.github/workflows/sub-cloudrun-deploy.yml
@@ -1,5 +1,7 @@
 name: Deploy to Cloud Run
 
+permissions: read-all
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Cuando no se declaran los permisos en el pipeline, se asume que tienen "write-all" el cual es un permiso muy abierto y hace que falle el SuperLint.

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs