### PR TITLE
fix(ci): workflow delete service & correct permission

### DIFF
--- a/.github/workflows/cd-deploy-to-dev.yml
+++ b/.github/workflows/cd-deploy-to-dev.yml
@@ -1,7 +1,5 @@
 name: Deploy to dev
 
-permissions: read-all
-
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/cd-deploy-to-prod.yml
+++ b/.github/workflows/cd-deploy-to-prod.yml
@@ -1,7 +1,5 @@
 name: Deploy to prod
 
-permissions: read-all
-
 on:
   release:
     types:

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -11,16 +11,6 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - name: Check if Cloud Run service exists
-        id: check_service
-        run: |
-          SERVICE_NAME=${{ env.GITHUB_REPOSITORY_NAME_PART_SLUG }}-${{ env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
-          if gcloud run services describe $SERVICE_NAME --region=${{ vars.GCP_REGION }} > /dev/null 2>&1; then
-            echo "service_exists=true" >> $GITHUB_ENV
-          else
-            echo "service_exists=false" >> $GITHUB_ENV
-          fi
-
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4.5.0
 
@@ -35,6 +25,16 @@ jobs:
 
       - name: 'Display information about the current gcloud environment'
         run: 'gcloud info'
+
+      - name: Check if Cloud Run service exists
+        id: check_service
+        run: |
+          SERVICE_NAME=${{ env.GITHUB_REPOSITORY_NAME_PART_SLUG }}-${{ env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
+          if gcloud run services describe $SERVICE_NAME --region=${{ vars.GCP_REGION }} > /dev/null 2>&1; then
+            echo "service_exists=true" >> $GITHUB_ENV
+          else
+            echo "service_exists=false" >> $GITHUB_ENV
+          fi
 
       - name: 'Delete service'
         if: env.service_exists == 'true'

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -1,7 +1,5 @@
 name: Delete Cloud Run instances on PR closed by merged
 
-permissions: read-all
-
 on:
   pull_request:
     branches:
@@ -13,6 +11,16 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - name: Check if Cloud Run service exists
+        id: check_service
+        run: |
+          SERVICE_NAME=${{ env.GITHUB_REPOSITORY_NAME_PART_SLUG }}-${{ env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }}
+          if gcloud run services describe $SERVICE_NAME --region=${{ vars.GCP_REGION }} > /dev/null 2>&1; then
+            echo "service_exists=true" >> $GITHUB_ENV
+          else
+            echo "service_exists=false" >> $GITHUB_ENV
+          fi
+
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4.5.0
 
@@ -25,8 +33,9 @@ jobs:
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v2'
 
-      - name: 'Use gcloud CLI'
+      - name: 'Display information about the current gcloud environment'
         run: 'gcloud info'
 
-      - name: Use gcloud CLI
+      - name: 'Delete service'
+        if: env.service_exists == 'true'
         run: gcloud run services delete ${{ env.GITHUB_REPOSITORY_NAME_PART_SLUG }}-${{ env.GITHUB_HEAD_REF_SLUG || env.GITHUB_REF_SLUG }} --region=${{ vars.GCP_REGION }} --quiet

--- a/.github/workflows/sub-build-push-image.yml
+++ b/.github/workflows/sub-build-push-image.yml
@@ -1,7 +1,5 @@
 name: Build docker image
 
-permissions: read-all
-
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/sub-cloudrun-deploy.yml
+++ b/.github/workflows/sub-cloudrun-deploy.yml
@@ -1,7 +1,5 @@
 name: Deploy to Cloud Run
 
-permissions: read-all
-
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
## Description

###  Check if service exists
checking for the existence of the service and the delete command only run if the service exists. This way some kind of errors will not occur

### Check: CKV2_GHA_1: "Ensure top-level permissions are not set to write-all"
The job or workflow run requires a permissions setting with id-token: write. You won't be able to request the OIDC JWT ID token if the permissions setting for id-token is set to read or none.

The linting tool is flagging the specific permissions granted within the workflow as potentially problematic, even if "write-all" is not explicitly stated. More description about the issue is below, This seems like an issue with Checkov.

https://github.com/super-linter/super-linter/issues/5652